### PR TITLE
SDT-209: Use timezone in current date/time variables

### DIFF
--- a/scripts/amdashboard/sdt/amdashboard-sdt-stats.sh
+++ b/scripts/amdashboard/sdt/amdashboard-sdt-stats.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-CURRENT_DATE=$(date +%d"/"%m"/"%Y)
-CURRENT_TIME=$(date +%T)
+CURRENT_DATE=$(TZ=Europe/London date +%d"/"%m"/"%Y)
+CURRENT_TIME=$(TZ=Europe/London date +%T)
 
 AZURE_DB="civil_sdt"
 


### PR DESCRIPTION
### Jira link (if applicable)
SDT-209 (https://tools.hmcts.net/jira/browse/SDT-209)


### Change description ###
Use timezone of Europe/London when setting CURRENT_DATE and CURRENT_TIME variables in amdashboard-sdt-stats.sh.  This ensures that time displayed on AM dashboard matches local time.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
