### PR TITLE
Update query to group Scotland offices as Scotland

### DIFF
--- a/scripts/daily/ccd-data-store-api-postgres-db-v15-prod-ccd_data_store-daily-etOnlineSubmissions.sh
+++ b/scripts/daily/ccd-data-store-api-postgres-db-v15-prod-ccd_data_store-daily-etOnlineSubmissions.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 cat <<EOF
 COPY (
-select data->>'managingOffice' as managingOffice,
+select case
+when case_event.case_type_id = 'ET_EnglandWales' then data ->> 'managingOffice'
+else 'Scotland'
+end as managingOffice,
 case
 when case_event.event_id = 'SUBMIT_CASE_DRAFT' then 'ET1 Online'
 when case_event.event_id = 'submitEt1Draft' then 'MyHMCTS ET1'


### PR DESCRIPTION
Update to query to only use managingOffice when EnglandWales so Scottish offices are grouped together and show as Scotland as opposed to individual records (Aberdeen, Dundee etc)